### PR TITLE
后端服务HEAD请求不上报数据问题

### DIFF
--- a/kong/plugins/skywalking/handler.lua
+++ b/kong/plugins/skywalking/handler.lua
@@ -45,6 +45,9 @@ function SkyWalkingHandler:body_filter(config)
 end
 
 function SkyWalkingHandler:log(config)
+  if string.upper(ngx.req.get_method()) =='HEAD' then
+    sw_tracer:finish()
+  end
   if kong.ctx.plugin.skywalking_sample then
     sw_tracer:prepareForReport()
   end


### PR DESCRIPTION
上游HEAD请求无响应体，不走body_filter，需要在log阶段执行下finish()函数